### PR TITLE
#27: Fixed error when using PATCH request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ def gsonVersion = "2.9.0"
 def jmesPathVersion = "0.5.1"
 def hamcrestVersion = "2.2"
 def commonsLang3Version = "3.12.0"
+def httpclientVersion = "4.5.13"
 
 sourceCompatibility = JavaVersion.VERSION_17
 group = "dev.gregorius.library"
@@ -50,6 +51,7 @@ dependencies {
 
     // Util
     implementation "org.apache.commons:commons-lang3:$commonsLang3Version"
+    implementation "org.apache.httpcomponents:httpclient:$httpclientVersion"
 }
 
 java {

--- a/src/main/java/dev/gregorius/library/json/reflect/JsonReflect.java
+++ b/src/main/java/dev/gregorius/library/json/reflect/JsonReflect.java
@@ -12,7 +12,7 @@ import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
@@ -69,7 +69,7 @@ public class JsonReflect {
 
     private static RestTemplate buildRestTemplate(final String baseUrl) {
         final RestTemplate newRestTemplate = new RestTemplate();
-        newRestTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
+        newRestTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(new HttpComponentsClientHttpRequestFactory()));
         newRestTemplate.setInterceptors(List.of(new LoggingInterceptor()));
         newRestTemplate.setErrorHandler(new NoopResponseErrorHandler());
         newRestTemplate.setMessageConverters(List.of(new StringHttpMessageConverter(UTF_8)));


### PR DESCRIPTION
Patch requests were not working, throwing an exception:

`org.springframework.web.client.ResourceAccessException: I/O error on PATCH request for "http://localhost:8082/penetrators/fbd2b146-ee20-43ab-86fd-954506751519": Invalid HTTP method: PATCH; nested exception is java.net.ProtocolException: Invalid HTTP method: PATCH`

The following solution was applied: https://stackoverflow.com/a/60223709/10355617